### PR TITLE
Fix loading local_app

### DIFF
--- a/lib/a9n.rb
+++ b/lib/a9n.rb
@@ -17,9 +17,13 @@ module A9n
     end
 
     def env
-      @env ||= local_app.env || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['APP_ENV']
+      @env ||= local_app_env || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['APP_ENV']
     end
-    
+
+    def local_app_env
+      local_app.env if local_app && local_app.respond_to?(:env)
+    end
+
     def local_app
       @local_app ||= get_rails
     end


### PR DESCRIPTION
When using only `A9n.load` (as described in README), `@local_app` never gets initialized.

Also, `ENV['RAILS_ENV']` seems to be deprecated.
