### PR TITLE
Fix behavior of fetch method for false value

### DIFF
--- a/lib/a9n/struct.rb
+++ b/lib/a9n/struct.rb
@@ -7,7 +7,7 @@ module A9n
     end
 
     def fetch(name, default = nil)
-      @table[name.to_sym] || default
+      @table.fetch(name.to_sym, default)
     end
 
     def method_missing(name, *args)

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -47,8 +47,20 @@ describe A9n::Struct do
       expect(subject.fetch(:non_empty_dwarf)).to eq('dwarf')
     end
 
-    it 'not returns nil for non existing value' do
+    it 'return false value' do
+      expect(subject.fetch(:false_dwarf)).to eq(false)
+    end
+
+    it 'return nil value' do
+      expect(subject.fetch(:nil_dwarf)).to eq(nil)
+    end
+
+    it 'return nil for non existing value' do
       expect(subject.fetch(:non_existing_dwarf)).to eq(nil)
+    end
+
+    it 'return default for non existing value' do
+      expect(subject.fetch(:non_existing_dwarf, 'default')).to eq('default')
     end
   end
 end


### PR DESCRIPTION
Currently when using `A9n.fetch(:false_value)`, we will receive `nil`. Also default is always returned in that case.
