### PR TITLE
use module level delegation instead of method_missing

### DIFF
--- a/lib/a9n/struct.rb
+++ b/lib/a9n/struct.rb
@@ -2,12 +2,26 @@ require 'ostruct'
 
 module A9n
   class Struct < OpenStruct
+
+    def blank?
+      to_h.none?
+    end
+
     def keys
       @table.keys
     end
 
     def fetch(name, default = nil)
       @table.fetch(name.to_sym, default)
+    end
+
+    def key?(key)
+      to_h.key?(key)
+    end
+
+    # backward compatibility for ruby < 2.0
+    def []=(key, value)
+      modifiable[new_ostruct_member(key)] = value
     end
 
     def method_missing(name, *args)

--- a/spec/integration/a9n_spec.rb
+++ b/spec/integration/a9n_spec.rb
@@ -8,6 +8,7 @@ describe A9n do
   before {
     subject.app = double(env: env)
     subject.root = File.expand_path("../../../test_app", __FILE__)
+    subject.load
   }
 
   after {

--- a/spec/unit/a9n_spec.rb
+++ b/spec/unit/a9n_spec.rb
@@ -105,41 +105,6 @@ describe A9n do
     it { expect(subject.get_env_var("IS_DWARF")).to be_nil}
   end
 
-  describe ".var_name_for" do
-    it { expect(subject.var_name_for(:configuration)).to eq(:@configuration) }
-    it { expect(subject.var_name_for("configuration.yml")).to eq(:@configuration) }
-    it { expect(subject.var_name_for("custom_dir/extra.yml")).to eq(:@extra) }
-  end
-
-  describe ".fetch" do
-    let(:example_config) { A9n::Struct.new({hello: "world"}) }
-    before {
-      expect(subject).to receive(:scope).with(subject::DEFAULT_SCOPE).twice.and_return(example_config)
-    }
-    it {
-      expect(subject.fetch(:hello)).to eq("world")
-      expect(subject.fetch(:wold)).to eq(nil)
-    }
-  end
-
-  describe ".scope" do
-    context "when config has been loaded" do
-      before {
-        subject.instance_variable_set(:@custom1, { api_key: '1234asdf'})
-        expect(subject).to receive(:load).never
-      }
-      it {
-        expect(subject.scope(:custom1)).to eq({ api_key: '1234asdf'})
-      }
-    end
-    context "when config has not been loaded yet" do
-      it {
-        expect(subject).to receive(:load)
-        subject.scope(:custom2)
-      }
-    end
-  end
-
   describe ".default_files" do
     before {
       subject.root = File.expand_path("../../../test_app", __FILE__)

--- a/test_app/benchmark.rb
+++ b/test_app/benchmark.rb
@@ -1,0 +1,29 @@
+require 'rubygems'
+require 'bundler/setup'
+require 'benchmark'
+require 'a9n'
+
+class SampleBenchmarkApp
+  def run
+    0.upto(1_000).map do |index|
+      "#{index} #{::A9n.string_dwarf} #{::A9n.overriden_dwarf}"
+    end
+  end
+
+  def root
+    Pathname.new('./test_app').expand_path
+  end
+
+  def env
+    :test
+  end
+end
+
+A9n.app = SampleBenchmarkApp.new
+results = []
+
+(1..10).each do
+  results << Benchmark.realtime { A9n.app.run }
+end
+
+puts (results.reduce(&:+) / 10).round(4)


### PR DESCRIPTION
Whille developing a feature in an app that uses A9n, I came across a performance issue, that turned out to be A9n related. Basic memoization solved the problem, but since we use A9n to store a lot of information, I thought that it's worth to look into it more thoroughly.

Benchmark shows, that delegation is far more efficient than method_missing:
```
# using method_missing:
$ ruby test_app/benchmark.rb 
$ 3.2284 seconds

# using delegation:
$ ruby test_app/benchmark.rb 
$ 0.003 seconds
``` 

My changes infer altering public interface, which might lead to backward compatibility issues. That might be not an issue as well, since public methods that I've deleted are used by A9n itself (and are not needed any more). 

~~Also, I included a little fix for arguments order in `A9n::Loader#verify!`.~~
