### PR TITLE
fix Loader#verify! arguments order

### DIFF
--- a/lib/a9n/loader.rb
+++ b/lib/a9n/loader.rb
@@ -53,7 +53,7 @@ module A9n
 
     private
 
-    def verify!(example, local)
+    def verify!(local, example)
       missing_keys = example.keys - local.keys
       if missing_keys.any?
         raise A9n::MissingConfigurationVariables.new("Following variables are missing in #{local_file} file: #{missing_keys.join(",")}")

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -89,10 +89,13 @@ describe A9n::Loader do
           expect(described_class).to receive(:load_yml).with(subject.example_file, env).and_return(example_config)
           expect(described_class).to receive(:load_yml).with(subject.local_file, env).and_return(local_config)
         end
-        it "raises expection"  do
+
+        let(:missing_variables_names) { example_config.keys - local_config.keys }
+
+        it "raises expection with missing variables names"  do
           expect {
             subject.load
-          }.to raise_error(A9n::MissingConfigurationVariables)
+          }.to raise_error(A9n::MissingConfigurationVariables, /#{missing_variables_names.join(', ')}/)
         end
       end
     end


### PR DESCRIPTION
Fixed `Loder#verify!` arguments order.
Extracted from #7.
