### PR TITLE
adds A9n.logger=

### DIFF
--- a/lib/a9n.rb
+++ b/lib/a9n.rb
@@ -20,6 +20,8 @@ module A9n
   DEFAULT_LOG_LEVEL = 'info'.freeze
 
   class << self
+    attr_writer :logger
+
     def env
       @env ||= ::A9n::StringInquirer.new(
         app_env ||

--- a/spec/unit/a9n_spec.rb
+++ b/spec/unit/a9n_spec.rb
@@ -249,6 +249,18 @@ RSpec.describe A9n do
     end
   end
 
+  describe '.logger=' do
+    it do
+      old_logger = subject.logger
+      new_logger = Logger.new(IO::NULL, level: :debug)
+      subject.logger = new_logger
+      expect(subject.logger).not_to eq(old_logger)
+      expect(subject.logger).to eq(new_logger)
+      expect(subject.logger).to be_a(Logger)
+      subject.logger = old_logger
+    end
+  end
+
   describe '.method_missing' do
     context 'when storage is empty' do
       before do


### PR DESCRIPTION
Resolves #17 by adding setter method to A9n module. This is handy to set to a debug level logger with a null device in specs to catch any typos inside of a logger block like
```ruby
A9n.logger = Logger.new(IO::NULL, level: :debug)

A9n.logger.info(self.class) { "#{undefined_variable}" }
```